### PR TITLE
Remove unused GroupInfo import

### DIFF
--- a/NachoBot-Bilibili-Adapter/bili_src/chat/private_handler.py
+++ b/NachoBot-Bilibili-Adapter/bili_src/chat/private_handler.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 from ncnk_message import (
     BaseMessageInfo,
     FormatInfo,
-    GroupInfo,
     MessageBase,
     Seg,
     UserInfo,


### PR DESCRIPTION
## Problem

The file `NachoBot-Bilibili-Adapter/bili_src/chat/private_handler.py` imports `ncnk_message.GroupInfo` but does not use it anywhere in the code. This violates lint rules, leading to unnecessary imports and potential code clutter.

## Solution

Removed the unused import of `GroupInfo` from the import statement in `private_handler.py` to keep the code clean and adhere to linting standards.

## Verification

- Ran linting tools (e.g., flake8 or pylint) to confirm no unused imports remain.
- Verified that the code's external behavior and functionality are unaffected, as `GroupInfo` was not referenced elsewhere.