### PR TITLE
 支持在集成规划器中解析原始JSON操作

### DIFF
--- a/NachoBot/src/chat/brain_chat/brain_planner.py
+++ b/NachoBot/src/chat/brain_chat/brain_planner.py
@@ -856,9 +856,14 @@ class BrainPlanner:
         # 解析LLM响应
         if llm_content:
             try:
-                if json_objects := self._extract_json_from_markdown(llm_content):
+                filtered_actions_list = list(filtered_actions.items())
+                json_objects = self._extract_json_from_markdown(llm_content)
+                if not json_objects:
+                    raw_json_objects = self._extract_json_from_raw_content(llm_content)
+                    json_objects = self._filter_raw_json_action_objects(raw_json_objects, filtered_actions_list)
+
+                if json_objects:
                     logger.debug(f"{self.log_prefix}从响应中提取到{len(json_objects)}个JSON对象")
-                    filtered_actions_list = list(filtered_actions.items())
                     for json_obj in json_objects:
                         actions.extend(self._parse_single_action(json_obj, message_id_list, filtered_actions_list))
                 else:
@@ -929,6 +934,63 @@ class BrainPlanner:
                 continue
 
         return json_objects
+
+    def _extract_json_from_raw_content(self, content: str) -> List[dict]:
+        """Parse raw JSON responses that are not wrapped in Markdown fences."""
+        raw_content = content.strip()
+        if not raw_content:
+            return []
+
+        if not (
+            (raw_content.startswith("{") and raw_content.endswith("}"))
+            or (raw_content.startswith("[") and raw_content.endswith("]"))
+        ):
+            return []
+
+        try:
+            json_obj = json.loads(repair_json(raw_content))
+            if isinstance(json_obj, dict):
+                return [json_obj]
+            if isinstance(json_obj, list):
+                return [item for item in json_obj if isinstance(item, dict)]
+        except Exception as e:
+            logger.warning(f"解析裸JSON失败: {e}, 内容: {raw_content[:100]}...")
+
+        return []
+
+    def _filter_raw_json_action_objects(
+        self,
+        json_objects: List[dict],
+        current_available_actions: List[Tuple[str, ActionInfo]],
+    ) -> List[dict]:
+        """Keep only supported actions from raw JSON fallback responses."""
+        if not json_objects:
+            return []
+
+        available_action_names = [action_name for action_name, _ in current_available_actions]
+        internal_action_names = ["no_reply", "reply", "wait_time", "make_appoint", "cancel_appoint"]
+        supported_actions = set(internal_action_names + available_action_names)
+        filtered_objects = []
+
+        for json_obj in json_objects:
+            action = json_obj.get("action")
+
+            if action in (None, "", "no_action"):
+                filtered_objects.append(
+                    {
+                        "action": "no_reply",
+                        "reason": json_obj.get("reason", "裸JSON响应未包含可执行动作"),
+                    }
+                )
+                continue
+
+            if action not in supported_actions:
+                logger.warning(f"{self.log_prefix}裸JSON响应包含不支持的动作: '{action}'")
+                continue
+
+            filtered_objects.append(json_obj)
+
+        return filtered_objects
 
 
 init_prompt()


### PR DESCRIPTION
在开启集成规划的时候，使用deepseek-v4-flash作为回复模型时，多次出现只回复原始JSON无法解析，导致规划器错误的选择不回复的问题，如图 
<img width="2288" height="426" alt="image" src="https://github.com/user-attachments/assets/3566e7a1-5fd5-43ab-89f9-0288ee4a4d71" />
<img width="2081" height="660" alt="image" src="https://github.com/user-attachments/assets/60b58cba-4112-4691-b6d3-0f14a31f3928" />


```markdown
## 变更说明

本 PR 为 integrated planner 增加裸 JSON action 解析兜底。

当前 integrated planner 主要从 Markdown 代码块中提取 action，例如：

```json
{
  "action": "reply",
  "text": "..."
}
```

但部分模型会直接返回裸 JSON，而不是使用 ```json 代码块包裹，例如：

```json
{
  "action": "reply",
  "text": "你好",
  "reason": "用户明确要求回复"
}
```

在这种情况下，原逻辑无法识别 action，会进入 `LLM没有返回可用动作` 分支，并最终执行 `no_reply`。

本 PR 在 Markdown JSON 提取失败后，增加了一层裸 JSON 解析兜底，使 integrated planner 能正确处理直接返回的 JSON action。

## 实现细节

- 保留原有 Markdown JSON 解析逻辑，优先级不变。
- 当 Markdown JSON 解析不到结果时，尝试解析完整响应内容。
- 仅当响应内容首尾符合 `{...}` 或 `[...]` 时才尝试裸 JSON 解析。
- 支持单个 JSON object 和 JSON array。
- 普通自然语言不会被自动转换为 `reply`，避免影响正常的 `no_reply` 行为。

## 修复的问题

修复 integrated planner 在模型返回裸 JSON action 时无法识别动作，导致错误执行 `no_reply` 的问题。

## 验证

已执行语法检查：

```bash
python -m py_compile NachoBot/src/chat/brain_chat/brain_planner.py
```
```

